### PR TITLE
centralized typing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
         files: "\\.(py)$"
         args: [--settings-path=pyproject.toml]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.304
+    rev: v1.1.305
     hooks:
       - id: pyright
         name: pyright

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ if __name__ == "__main__":
 Before the first commit:
 
 ```bash
-pip install -e .[dev,wandb]
+pip install -e .[dev,scripts]
 pre-commit install
 pre-commit run --all-files
 ```

--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -5,6 +5,7 @@ from math import prod
 from typing import ClassVar, Sequence
 
 import torch
+
 from gfn.typing import BatchActionsTensor, BatchBoolTensor, OneActionTensor
 
 

--- a/src/gfn/actions.py
+++ b/src/gfn/actions.py
@@ -5,12 +5,7 @@ from math import prod
 from typing import ClassVar, Sequence
 
 import torch
-from torchtyping import TensorType
-
-# Typing
-OneActionTensor = TensorType["action_shape"]
-ActionsTensor = TensorType["batch_shape", "action_shape"]
-BoolTensor = TensorType["batch_shape", torch.bool]
+from gfn.typing import BatchActionsTensor, BatchBoolTensor, OneActionTensor
 
 
 class Actions(ABC):
@@ -27,7 +22,7 @@ class Actions(ABC):
     # The following class variable corresponds to $s \rightarrow s_f$ transitions
     exit_action: ClassVar[OneActionTensor]  # action to exit the environment
 
-    def __init__(self, tensor: ActionsTensor):
+    def __init__(self, tensor: BatchActionsTensor):
         """Initialize actions from a tensor.
         Args:
             tensor: tensor of actions
@@ -102,7 +97,7 @@ class Actions(ABC):
                 "extend_with_dummy_actions is only implemented for bi-dimensional actions."
             )
 
-    def compare(self, other: ActionsTensor) -> BoolTensor:
+    def compare(self, other: BatchActionsTensor) -> BatchBoolTensor:
         """Compares the actions to a tensor of actions.
         Args:
             other: tensor of actions
@@ -116,7 +111,7 @@ class Actions(ABC):
         return out
 
     @property
-    def is_dummy(self) -> BoolTensor:
+    def is_dummy(self) -> BatchBoolTensor:
         """Returns a boolean tensor indicating whether the actions are dummy actiosn."""
         dummy_actions_tensor = self.__class__.dummy_action.repeat(
             *self.batch_shape, *((1,) * len(self.__class__.action_shape))
@@ -124,7 +119,7 @@ class Actions(ABC):
         return self.compare(dummy_actions_tensor)
 
     @property
-    def is_exit(self) -> BoolTensor:
+    def is_exit(self) -> BatchBoolTensor:
         """Returns a boolean tensor indicating whether the actions are exit actions."""
         exit_actions_tensor = self.__class__.exit_action.repeat(
             *self.batch_shape, *((1,) * len(self.__class__.action_shape))

--- a/src/gfn/casting.py
+++ b/src/gfn/casting.py
@@ -1,13 +1,7 @@
+# TODO: remove this file eventually
 from typing import cast
 
-import torch
-from torchtyping import TensorType
-
-# Typing.
-ForwardMasksTensor = TensorType["batch_shape", "n_actions", torch.bool]
-BackwardMasksTensor = TensorType["batch_shape", "n_actions - 1", torch.bool]
-
-# TODO: remove this file eventually
+from gfn.typing import ForwardMasksTensor, BackwardMasksTensor
 
 
 def correct_cast(

--- a/src/gfn/casting.py
+++ b/src/gfn/casting.py
@@ -1,7 +1,7 @@
 # TODO: remove this file eventually
 from typing import cast
 
-from gfn.typing import ForwardMasksTensor, BackwardMasksTensor
+from gfn.typing import BackwardMasksTensor, ForwardMasksTensor
 
 
 def correct_cast(

--- a/src/gfn/containers/base.py
+++ b/src/gfn/containers/base.py
@@ -8,13 +8,6 @@ if TYPE_CHECKING:
     from gfn.envs import Env
 
 import torch
-from torchtyping import TensorType
-
-# Typing  --- n_transitions is an int
-Tensor2D = TensorType["max_length", "n_trajectories", torch.long]
-Tensor2D2 = TensorType["n_trajectories", "shape"]
-Tensor1D = TensorType["n_trajectories", torch.long]
-FloatTensor1D = TensorType["n_trajectories", torch.float]
 
 
 class Container(ABC):

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -12,9 +12,9 @@ import torch
 from gfn.containers.base import Container
 from gfn.containers.transitions import Transitions
 from gfn.typing import (
-    TrajectoriesFloatTensor2D, 
-    TrajectoriesLongTensor1D, 
     TrajectoriesFloatTensor1D,
+    TrajectoriesFloatTensor2D,
+    TrajectoriesLongTensor1D,
 )
 
 
@@ -173,15 +173,16 @@ class Trajectories(Container):
         new_actions = torch.cat(
             [new_actions, torch.full((1, len(trajectories)), -1)], dim=0
         )
-        
+
         # env.sf should never be None unless something went wrong during class instantiation.
         if trajectories.env.sf is None:
             raise AttributeError(
                 "Something went wrong during the instantiation of environment {}".format(
-                    trajectories.env)
+                    trajectories.env
                 )
+            )
 
-        new_states = trajectories.env.sf.repeat( 
+        new_states = trajectories.env.sf.repeat(
             trajectories.when_is_done.max() + 1, len(trajectories), 1
         )
         new_when_is_done = trajectories.when_is_done + 1
@@ -190,11 +191,11 @@ class Trajectories(Container):
             new_actions[trajectories.when_is_done[i], i] = (
                 trajectories.env.n_actions - 1
             )
-            
+
             new_actions[: trajectories.when_is_done[i], i] = trajectories.actions[
                 : trajectories.when_is_done[i], i
             ].flip(0)
-            
+
             new_states[
                 : trajectories.when_is_done[i] + 1, i
             ] = trajectories.states.tensor[: trajectories.when_is_done[i] + 1, i].flip(

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -81,7 +81,7 @@ class Trajectories(Container):
         )
 
     def __repr__(self) -> str:
-        states = self.states.states_tensor.transpose(0, 1)
+        states = self.states.tensor.transpose(0, 1)
         assert states.ndim == 3
         trajectories_representation = ""
         for traj in states[:10]:
@@ -93,7 +93,7 @@ class Trajectories(Container):
             trajectories_representation += "-> ".join(one_traj_repr) + "\n"
         return (
             f"Trajectories(n_trajectories={self.n_trajectories}, max_length={self.max_length}, First 10 trajectories:"
-            + f"states=\n{trajectories_representation}, actions=\n{self.actions.actions_tensor.transpose(0, 1)[:10].numpy()}, "
+            + f"states=\n{trajectories_representation}, actions=\n{self.actions.tensor.transpose(0, 1)[:10].numpy()}, "
             + f"when_is_done={self.when_is_done[:10].numpy()})"
         )
 
@@ -189,7 +189,7 @@ class Trajectories(Container):
             ].flip(0)
             new_states[
                 : trajectories.when_is_done[i] + 1, i
-            ] = trajectories.states.states_tensor[
+            ] = trajectories.states.tensor[
                 : trajectories.when_is_done[i] + 1, i
             ].flip(
                 0

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -8,17 +8,14 @@ if TYPE_CHECKING:
     from gfn.states import States
 
 import torch
-from torchtyping import TensorType
 
 from gfn.containers.base import Container
 from gfn.containers.transitions import Transitions
-
-# Typing  --- n_transitions is an int
-Tensor2D = TensorType["max_length", "n_trajectories", torch.long]
-FloatTensor2D = TensorType["max_length", "n_trajectories", torch.float]
-Tensor2D2 = TensorType["n_trajectories", "shape"]
-Tensor1D = TensorType["n_trajectories", torch.long]
-FloatTensor1D = TensorType["n_trajectories", torch.float]
+from gfn.typing import (
+    TrajectoriesFloatTensor2D, 
+    TrajectoriesLongTensor1D, 
+    TrajectoriesFloatTensor1D,
+)
 
 
 class Trajectories(Container):
@@ -27,10 +24,10 @@ class Trajectories(Container):
         env: Env,
         states: States | None = None,
         actions: Actions | None = None,
-        when_is_done: Tensor1D | None = None,
+        when_is_done: TrajectoriesLongTensor1D | None = None,
         is_backward: bool = False,
-        log_rewards: FloatTensor1D | None = None,
-        log_probs: FloatTensor2D | None = None,
+        log_rewards: TrajectoriesFloatTensor1D | None = None,
+        log_probs: TrajectoriesFloatTensor2D | None = None,
     ) -> None:
         """Container for complete trajectories (starting in s_0 and ending in s_f).
         Trajectories are represented as a States object with bi-dimensional batch shape.
@@ -46,10 +43,10 @@ class Trajectories(Container):
             env (Env): The environment in which the trajectories are defined.
             states (States, optional): The states of the trajectories. Defaults to None.
             actions (Actions, optional): The actions of the trajectories. Defaults to None.
-            when_is_done (Tensor1D, optional): The time step at which each trajectory ends. Defaults to None.
+            when_is_done (TrajectoriesLongTensor1D, optional): The time step at which each trajectory ends. Defaults to None.
             is_backward (bool, optional): Whether the trajectories are backward or forward. Defaults to False.
-            log_rewards (FloatTensor1D, optional): The log_rewards of the trajectories. Defaults to None.
-            log_probs (FloatTensor2D, optional): The log probabilities of the trajectories' actions. Defaults to None.
+            log_rewards (TrajectoriesFloatTensor1D, optional): The log_rewards of the trajectories. Defaults to None.
+            log_probs (TrajectoriesFloatTensor2D, optional): The log probabilities of the trajectories' actions. Defaults to None.
 
         If states is None, then the states are initialized to an empty States object, that can be populated on the fly.
         If log_rewards is None, then `env.log_reward` is used to compute the rewards, at each call of self.log_rewards
@@ -116,7 +113,7 @@ class Trajectories(Container):
         return self.states[self.when_is_done - 1, torch.arange(self.n_trajectories)]
 
     @property
-    def log_rewards(self) -> FloatTensor1D | None:
+    def log_rewards(self) -> TrajectoriesFloatTensor1D | None:
         if self._log_rewards is not None:
             assert self._log_rewards.shape == (self.n_trajectories,)
             return self._log_rewards

--- a/src/gfn/containers/transitions.py
+++ b/src/gfn/containers/transitions.py
@@ -86,8 +86,8 @@ class Transitions(Container):
         return self.n_transitions
 
     def __repr__(self):
-        states_tensor = self.states.states_tensor
-        next_states_tensor = self.next_states.states_tensor
+        states_tensor = self.states.tensor
+        next_states_tensor = self.next_states.tensor
 
         states_repr = ",\t".join(
             [

--- a/src/gfn/distributions.py
+++ b/src/gfn/distributions.py
@@ -3,14 +3,11 @@ from collections import Counter
 from typing import Optional
 
 import torch
-from torchtyping import TensorType
 
 from gfn.containers import Trajectories
 from gfn.envs import Env
 from gfn.states import States
-
-# Typing
-TensorPmf = TensorType["n_states", float]
+from gfn.typing import PmfTensor
 
 
 class TrajectoryDistribution(ABC):
@@ -32,7 +29,7 @@ class TerminatingStatesDistribution(ABC):
     """
 
     @abstractmethod
-    def pmf(self) -> TensorPmf:
+    def pmf(self) -> PmfTensor:
         """
         Compute the probability mass function of the distribution.
         """
@@ -65,7 +62,7 @@ class EmpiricalTerminatingStatesDistribution(TerminatingStatesDistribution):
         self.states_to_indices = env.get_terminating_states_indices
         self.env_n_terminating_states = env.n_terminating_states
 
-    def pmf(self) -> TensorPmf:
+    def pmf(self) -> PmfTensor:
         states_indices = self.states_to_indices(self.states).cpu().numpy().tolist()
         counter = Counter(states_indices)
         counter_list = [
@@ -98,7 +95,7 @@ class TrajectoryBasedTerminatingStateDistribution(TerminatingStatesDistribution)
         trajectories = self.trajectory_distribution.sample(n_final_states)
         return trajectories.last_states
 
-    def pmf(self) -> TensorPmf:
+    def pmf(self) -> PmfTensor:
         """
         Compute the probability mass function of the distribution.
         """

--- a/src/gfn/envs/box.py
+++ b/src/gfn/envs/box.py
@@ -7,7 +7,7 @@ from torchtyping import TensorType
 from gfn.actions import Actions
 from gfn.envs.env import Env
 from gfn.states import States
-from gfn.envs.typing import BatchFloatTensor
+from gfn.typing import BatchFloatTensor
 
 # Typing specific to Box environment.
 StatesTensor = TensorType["batch_shape", 2, torch.float]

--- a/src/gfn/envs/box.py
+++ b/src/gfn/envs/box.py
@@ -69,10 +69,10 @@ class BoxEnv(Env):
         return BoxActions
 
     def maskless_step(self, states: States, actions: Actions) -> StatesTensor:
-        return states.states_tensor + actions.actions_tensor
+        return states.tensor + actions.tensor
 
     def maskless_backward_step(self, states: States, actions: Actions) -> StatesTensor:
-        return states.states_tensor - actions.actions_tensor
+        return states.tensor - actions.tensor
 
     @staticmethod
     def norm(x: StatesTensor) -> torch.Tensor:
@@ -89,13 +89,13 @@ class BoxEnv(Env):
             return False
 
         if not backward:
-            actions_at_s0 = non_exit_actions[s0_states_idx].actions_tensor
+            actions_at_s0 = non_exit_actions[s0_states_idx].tensor
 
             if torch.any(self.norm(actions_at_s0) > self.delta):
                 return False
 
         non_s0_states = non_terminal_states[~s0_states_idx].states_tensor
-        non_s0_actions = non_exit_actions[~s0_states_idx].actions_tensor
+        non_s0_actions = non_exit_actions[~s0_states_idx].tensor
 
         if torch.any(self.norm(non_s0_actions) != self.delta) or torch.any(
             non_s0_actions < 0
@@ -119,7 +119,7 @@ class BoxEnv(Env):
 
     def log_reward(self, final_states: States) -> TensorFloat:
         R0, R1, R2 = (self.R0, self.R1, self.R2)
-        ax = abs(final_states.states_tensor - 0.5)
+        ax = abs(final_states.tensor - 0.5)
         reward = (
             R0 + (0.25 < ax).prod(-1) * R1 + ((0.3 < ax) * (ax < 0.4)).prod(-1) * R2
         )

--- a/src/gfn/envs/box.py
+++ b/src/gfn/envs/box.py
@@ -9,7 +9,7 @@ from gfn.envs.env import Env
 from gfn.states import States
 from gfn.envs.typing import BatchFloatTensor
 
-# Typing
+# Typing specific to Box environment.
 StatesTensor = TensorType["batch_shape", 2, torch.float]
 OneActionTensor = TensorType[2]
 

--- a/src/gfn/envs/discrete_ebm.py
+++ b/src/gfn/envs/discrete_ebm.py
@@ -12,7 +12,7 @@ from gfn.states import DiscreteStates, States
 from gfn.typing import (
     ForwardMasksTensor, BackwardMasksTensor, StatesFloatTensor, BatchGenericTensor)
 
-# Typing
+# Typing specific to Ising Model environment.
 IsingJTensor = TensorType["state_shape", "state_shape", torch.float]
 
 

--- a/src/gfn/envs/discrete_ebm.py
+++ b/src/gfn/envs/discrete_ebm.py
@@ -10,7 +10,11 @@ from gfn.actions import Actions
 from gfn.envs.env import DiscreteEnv
 from gfn.states import DiscreteStates, States
 from gfn.typing import (
-    ForwardMasksTensor, BackwardMasksTensor, StatesFloatTensor, BatchGenericTensor)
+    BackwardMasksTensor,
+    BatchGenericTensor,
+    ForwardMasksTensor,
+    StatesFloatTensor,
+)
 
 # Typing specific to Ising Model environment.
 IsingJTensor = TensorType["state_shape", "state_shape", torch.float]
@@ -155,7 +159,9 @@ class DiscreteEBMEnv(DiscreteEnv):
         )
         return states.tensor
 
-    def maskless_backward_step(self, states: States, actions: Actions) -> StatesFloatTensor:
+    def maskless_backward_step(
+        self, states: States, actions: Actions
+    ) -> StatesFloatTensor:
         # In this env, states are n-dim vectors. s0 is empty (represented as -1),
         # so s0=[-1, -1, ..., -1], each action is replacing a -1 with either a
         # 0 or 1. Action i in [0, ndim-1] os replacing s[i] with 0, whereas
@@ -179,7 +185,9 @@ class DiscreteEBMEnv(DiscreteEnv):
         canonical_base = 3 ** torch.arange(self.ndim - 1, -1, -1, device=self.device)
         return (states_raw + 1).mul(canonical_base).sum(-1).long()
 
-    def get_terminating_states_indices(self, states: DiscreteStates) -> BatchGenericTensor:
+    def get_terminating_states_indices(
+        self, states: DiscreteStates
+    ) -> BatchGenericTensor:
         states_raw = states.tensor
         canonical_base = 2 ** torch.arange(self.ndim - 1, -1, -1, device=self.device)
         return (states_raw).mul(canonical_base).sum(-1).long()

--- a/src/gfn/envs/env.py
+++ b/src/gfn/envs/env.py
@@ -157,7 +157,7 @@ class Env(ABC):
             )
 
         new_sink_states_idx = actions.is_exit
-        new_states.states_tensor[new_sink_states_idx] = self.sf
+        new_states.tensor[new_sink_states_idx] = self.sf
         new_sink_states_idx = ~valid_states_idx | new_sink_states_idx
 
         not_done_states = new_states[~new_sink_states_idx]
@@ -169,7 +169,7 @@ class Env(ABC):
         # if isinstance(new_states, DiscreteStates):
         #     new_not_done_states.masks = self.update_masks(not_done_states, not_done_actions)
 
-        new_states.states_tensor[~new_sink_states_idx] = new_not_done_states_tensor
+        new_states.tensor[~new_sink_states_idx] = new_not_done_states_tensor
 
         if isinstance(new_states, DiscreteStates):  # TODO: move this to DiscreteEnv ?
             new_states.update_masks()  # TODO: probably use `not_done_actions` (and `not_done_states` `~new_sink_states` ?) as input to update_masks
@@ -197,7 +197,7 @@ class Env(ABC):
         new_not_done_states_tensor = self.maskless_backward_step(
             valid_states, valid_actions
         )
-        new_states.states_tensor[valid_states_idx] = new_not_done_states_tensor
+        new_states.tensor[valid_states_idx] = new_not_done_states_tensor
 
         if isinstance(new_states, DiscreteStates):
             new_states.update_masks()
@@ -308,5 +308,4 @@ class DiscreteEnv(Env, ABC):
     ) -> bool:
         assert states.forward_masks is not None and states.backward_masks is not None
         masks_tensor = states.backward_masks if backward else states.forward_masks
-        actions_tensor = actions.actions_tensor
-        return torch.gather(masks_tensor, 1, actions_tensor).all()
+        return torch.gather(masks_tensor, 1, actions.tensor).all()

--- a/src/gfn/envs/env.py
+++ b/src/gfn/envs/env.py
@@ -14,7 +14,6 @@ from gfn.typing import (
     BatchFloatTensor,
     BatchLongTensor,
     OneStateTensor,
-    OneStateTensor,
     PmfTensor,
     StatesFloatTensor,
 )
@@ -110,7 +109,9 @@ class Env(ABC):
         pass
 
     @abstractmethod
-    def maskless_backward_step(self, states: States, actions: Actions) -> StatesFloatTensor:
+    def maskless_backward_step(
+        self, states: States, actions: Actions
+    ) -> StatesFloatTensor:
         """Function that takes a batch of states and actions and returns a batch of previous
         states. Does not need to check whether the actions are valid or the states are sink states.
         """

--- a/src/gfn/envs/hypergrid.py
+++ b/src/gfn/envs/hypergrid.py
@@ -16,11 +16,11 @@ from gfn.envs.preprocessors import (
 )
 from gfn.states import DiscreteStates
 from gfn.typing import (
-    ForwardMasksTensor,
     BackwardMasksTensor,
-    StatesFloatTensor,
-    BatchTensorLong,
     BatchTensorFloat,
+    BatchTensorLong,
+    ForwardMasksTensor,
+    StatesFloatTensor,
 )
 
 preprocessors_dict = {
@@ -126,7 +126,9 @@ class HyperGrid(DiscreteEnv):
 
         return HyperGridStates
 
-    def maskless_step(self, states: DiscreteStates, actions: Actions) -> StatesFloatTensor:
+    def maskless_step(
+        self, states: DiscreteStates, actions: Actions
+    ) -> StatesFloatTensor:
         new_states_tensor = states.tensor.scatter(-1, actions.tensor, 1, reduce="add")
         return new_states_tensor
 

--- a/src/gfn/envs/hypergrid.py
+++ b/src/gfn/envs/hypergrid.py
@@ -124,27 +124,27 @@ class HyperGrid(DiscreteEnv):
                 self.forward_masks = cast(ForwardMasksTensor, self.forward_masks)
                 self.backward_masks = cast(BackwardMasksTensor, self.backward_masks)
 
-                self.forward_masks[..., :-1] = self.states_tensor != env.height - 1
-                self.backward_masks = self.states_tensor != 0
+                self.forward_masks[..., :-1] = self.tensor != env.height - 1
+                self.backward_masks = self.tensor != 0
 
         return HyperGridStates
 
     def maskless_step(self, states: DiscreteStates, actions: Actions) -> StatesTensor:
-        new_states_tensor = states.states_tensor.scatter(
-            -1, actions.actions_tensor, 1, reduce="add"
+        new_states_tensor = states.tensor.scatter(
+            -1, actions.tensor, 1, reduce="add"
         )
         return new_states_tensor
 
     def maskless_backward_step(
         self, states: DiscreteStates, actions: Actions
     ) -> StatesTensor:
-        new_states_tensor = states.states_tensor.scatter(
-            -1, actions.actions_tensor, -1, reduce="add"
+        new_states_tensor = states.tensor.scatter(
+            -1, actions.tensor, -1, reduce="add"
         )
         return new_states_tensor
 
     def true_reward(self, final_states: DiscreteStates) -> TensorFloat:
-        final_states_raw = final_states.states_tensor
+        final_states_raw = final_states.tensor
         R0, R1, R2 = (self.R0, self.R1, self.R2)
         ax = abs(final_states_raw / (self.height - 1) - 0.5)
         if not self.reward_cos:
@@ -161,7 +161,7 @@ class HyperGrid(DiscreteEnv):
         return torch.log(self.true_reward(final_states))
 
     def get_states_indices(self, states: DiscreteStates) -> TensorLong:
-        states_raw = states.states_tensor
+        states_raw = states.tensor
 
         canonical_base = self.height ** torch.arange(
             self.ndim - 1, -1, -1, device=states_raw.device
@@ -219,7 +219,7 @@ class HyperGrid(DiscreteEnv):
     @property
     def all_states(self) -> DiscreteStates:
         grid = self.build_grid()
-        flat_grid = rearrange(grid.states_tensor, "... ndim -> (...) ndim")
+        flat_grid = rearrange(grid.tensor, "... ndim -> (...) ndim")
         return self.States(flat_grid)
 
     @property

--- a/src/gfn/envs/preprocessors/base.py
+++ b/src/gfn/envs/preprocessors/base.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Callable, Tuple
 
 from gfn.states import States
-from gfn.typing import BatchOutputTensor
+from gfn.typing import BatchInputTensor
 
 
 class Preprocessor(ABC):
@@ -15,10 +15,10 @@ class Preprocessor(ABC):
         self.output_shape = output_shape
 
     @abstractmethod
-    def preprocess(self, states: States) -> BatchOutputTensor:
+    def preprocess(self, states: States) -> BatchInputTensor:
         pass
 
-    def __call__(self, states: States) -> BatchOutputTensor:
+    def __call__(self, states: States) -> BatchInputTensor:
         return self.preprocess(states)
 
     def __repr__(self):
@@ -29,14 +29,14 @@ class IdentityPreprocessor(Preprocessor):
     """Simple preprocessor applicable to environments with uni-dimensional states.
     This is the default preprocessor used."""
 
-    def preprocess(self, states: States) -> BatchOutputTensor:
+    def preprocess(self, states: States) -> BatchInputTensor:
         return states.tensor.float()
 
 
 class EnumPreprocessor(Preprocessor):
     "Preprocessor applicable to environments with discrete states."
 
-    def __init__(self, get_states_indices: Callable[[States], BatchOutputTensor]) -> None:
+    def __init__(self, get_states_indices: Callable[[States], BatchInputTensor]) -> None:
         """Preprocessor for environments with enumerable states (finite number of states).
         Each state is represented by a unique integer (>= 0) index.
 

--- a/src/gfn/envs/preprocessors/base.py
+++ b/src/gfn/envs/preprocessors/base.py
@@ -34,7 +34,7 @@ class IdentityPreprocessor(Preprocessor):
     This is the default preprocessor used."""
 
     def preprocess(self, states: States) -> OutputTensor:
-        return states.states_tensor.float()
+        return states.tensor.float()
 
 
 class EnumPreprocessor(Preprocessor):

--- a/src/gfn/envs/preprocessors/base.py
+++ b/src/gfn/envs/preprocessors/base.py
@@ -36,7 +36,9 @@ class IdentityPreprocessor(Preprocessor):
 class EnumPreprocessor(Preprocessor):
     "Preprocessor applicable to environments with discrete states."
 
-    def __init__(self, get_states_indices: Callable[[States], BatchInputTensor]) -> None:
+    def __init__(
+        self, get_states_indices: Callable[[States], BatchInputTensor]
+    ) -> None:
         """Preprocessor for environments with enumerable states (finite number of states).
         Each state is represented by a unique integer (>= 0) index.
 

--- a/src/gfn/envs/preprocessors/hot.py
+++ b/src/gfn/envs/preprocessors/hot.py
@@ -53,7 +53,7 @@ class KHotPreprocessor(Preprocessor):
         self.get_states_indices = get_states_indices
 
     def preprocess(self, states):
-        states_tensor = states.states_tensor
+        states_tensor = states.tensor
         assert (
             states_tensor.dtype == torch.long
         ), "K Hot preprocessing only works for integer states"

--- a/src/gfn/envs/preprocessors/hot.py
+++ b/src/gfn/envs/preprocessors/hot.py
@@ -6,14 +6,14 @@ from torch.nn.functional import one_hot
 
 from gfn.envs.preprocessors.base import Preprocessor
 from gfn.states import States
-from gfn.typing import BatchOutputTensor
+from gfn.typing import BatchInputTensor
 
 
 class OneHotPreprocessor(Preprocessor):
     def __init__(
         self,
         n_states: int,
-        get_states_indices: Callable[[States], BatchOutputTensor],
+        get_states_indices: Callable[[States], BatchInputTensor],
     ) -> None:
         """One Hot Preprocessor for environments with enumerable states (finite number of states).
 
@@ -35,7 +35,7 @@ class KHotPreprocessor(Preprocessor):
         self,
         height: int,
         ndim: int,
-        get_states_indices: Callable[[States], BatchOutputTensor],
+        get_states_indices: Callable[[States], BatchInputTensor],
     ) -> None:
         """K Hot Preprocessor for environments with enumerable states (finite number of states) with a grid structure.
 

--- a/src/gfn/estimators.py
+++ b/src/gfn/estimators.py
@@ -6,9 +6,7 @@ from torchtyping import TensorType
 
 from gfn.envs import DiscreteEnv, Env
 from gfn.states import DiscreteStates, States
-
-# Typing
-OutputTensor = TensorType["batch_shape", "output_dim", float]
+from gfn.typing import BatchOutputFloatTensor
 
 
 class FunctionEstimator(ABC):
@@ -39,7 +37,7 @@ class FunctionEstimator(ABC):
         self.preprocessor = env.preprocessor
         self.output_dim_is_checked = False
 
-    def __call__(self, states: States) -> OutputTensor:
+    def __call__(self, states: States) -> BatchOutputFloatTensor:
         out = self.module(self.preprocessor(states))
         if not self.output_dim_is_checked:
             self.check_output_dim(out)
@@ -48,7 +46,7 @@ class FunctionEstimator(ABC):
         return out
 
     @abstractmethod
-    def check_output_dim(self, module_output: OutputTensor) -> None:
+    def check_output_dim(self, module_output: BatchOutputFloatTensor) -> None:
         """Check that the output of the module has the correct shape. Raises an error if not."""
         pass
 
@@ -71,7 +69,7 @@ class LogEdgeFlowEstimator(FunctionEstimator):
     # TODO: make it work for continuous environments.
     """
 
-    def check_output_dim(self, module_output: OutputTensor):
+    def check_output_dim(self, module_output: BatchOutputFloatTensor):
         if not isinstance(self.env, DiscreteEnv):
             raise ValueError(
                 "LogEdgeFlowEstimator only supports discrete environments."
@@ -85,7 +83,7 @@ class LogEdgeFlowEstimator(FunctionEstimator):
 class LogStateFlowEstimator(FunctionEstimator):
     r"""Container for estimators $s \mapsto \log F(s)$."""
 
-    def check_output_dim(self, module_output: OutputTensor):
+    def check_output_dim(self, module_output: BatchOutputFloatTensor):
         if module_output.shape[-1] != 1:
             raise ValueError(
                 f"LogStateFlowEstimator output dimension should be 1, but is {module_output.shape[-1]}."
@@ -105,7 +103,7 @@ class ProbabilityEstimator(FunctionEstimator, ABC):
 
     @abstractmethod
     def to_probability_distribution(
-        self, states: States, module_output: OutputTensor
+        self, states: States, module_output: BatchOutputFloatTensor
     ) -> Distribution:
         """Transform the output of the module into a probability distribution."""
         pass
@@ -119,7 +117,7 @@ class LogEdgeFlowProbabilityEstimator(ProbabilityEstimator, LogEdgeFlowEstimator
     {\sum_{s' \in Children(s)} F(s \rightarrow s')}$."""
 
     def to_probability_distribution(
-        self, states: DiscreteStates, module_output: OutputTensor
+        self, states: DiscreteStates, module_output: BatchOutputFloatTensor
     ) -> Distribution:
         logits = module_output
         logits[~states.forward_masks] = -float("inf")

--- a/src/gfn/examples/estimators.py
+++ b/src/gfn/examples/estimators.py
@@ -1,13 +1,10 @@
 import torch
 from torch.distributions import Categorical, Distribution
-from torchtyping import TensorType
 
 from gfn.envs import DiscreteEnv
 from gfn.estimators import ProbabilityEstimator
 from gfn.states import DiscreteStates
-
-# Typing
-OutputTensor = TensorType["batch_shape", "output_dim", float]
+from gfn.typing import BatchOutputTensor
 
 
 class DiscretePFEstimator(ProbabilityEstimator):
@@ -37,7 +34,7 @@ class DiscretePFEstimator(ProbabilityEstimator):
         self.sf_bias = sf_bias
         self.epsilon = epsilon
 
-    def check_output_dim(self, module_output: OutputTensor):
+    def check_output_dim(self, module_output: BatchOutputTensor):
         if not isinstance(self.env, DiscreteEnv):
             raise ValueError("DiscretePFEstimator only supports discrete environments.")
         if module_output.shape[-1] != self.env.n_actions:
@@ -46,7 +43,7 @@ class DiscretePFEstimator(ProbabilityEstimator):
             )
 
     def to_probability_distribution(
-        self, states: DiscreteStates, module_output: OutputTensor
+        self, states: DiscreteStates, module_output: BatchOutputTensor
     ) -> Distribution:
         logits = module_output
         logits[~states.forward_masks] = -float("inf")
@@ -64,7 +61,7 @@ class DiscretePFEstimator(ProbabilityEstimator):
 class DiscretePBEstimator(ProbabilityEstimator):
     r"""Container for estimators $s \mapsto (P_B(s' \mid s))_{s' \in Parents(s)}$"""
 
-    def check_output_dim(self, module_output: OutputTensor):
+    def check_output_dim(self, module_output: BatchOutputTensor):
         if not isinstance(self.env, DiscreteEnv):
             raise ValueError("DiscretePBEstimator only supports discrete environments.")
         if module_output.shape[-1] != self.env.n_actions - 1:
@@ -73,7 +70,7 @@ class DiscretePBEstimator(ProbabilityEstimator):
             )
 
     def to_probability_distribution(
-        self, states: DiscreteStates, module_output: OutputTensor
+        self, states: DiscreteStates, module_output: BatchOutputTensor
     ) -> Distribution:
         logits = module_output
         logits[~states.backward_masks] = -float("inf")

--- a/src/gfn/examples/modules.py
+++ b/src/gfn/examples/modules.py
@@ -4,7 +4,9 @@ from typing import Literal, Optional
 
 import torch
 import torch.nn as nn
+
 from gfn.typing import BatchInputFloatTensor, BatchOutputFloatTensor
+
 
 class NeuralNet(nn.Module):
     """Implements a basic MLP."""
@@ -47,7 +49,9 @@ class NeuralNet(nn.Module):
         self.last_layer = nn.Linear(self.torso.hidden_dim, output_dim)
         self.device = None
 
-    def forward(self, preprocessed_states: BatchInputFloatTensor) -> BatchOutputFloatTensor:
+    def forward(
+        self, preprocessed_states: BatchInputFloatTensor
+    ) -> BatchOutputFloatTensor:
         if self.device is None:
             self.device = preprocessed_states.device
             self.to(self.device)
@@ -75,7 +79,9 @@ class Tabular(nn.Module):
 
         self.device = None
 
-    def __call__(self, preprocessed_states: BatchInputFloatTensor) -> BatchOutputFloatTensor:
+    def __call__(
+        self, preprocessed_states: BatchInputFloatTensor
+    ) -> BatchOutputFloatTensor:
         if self.device is None:
             self.device = preprocessed_states.device
             self.table = self.table.to(self.device)

--- a/src/gfn/examples/modules.py
+++ b/src/gfn/examples/modules.py
@@ -4,12 +4,7 @@ from typing import Literal, Optional
 
 import torch
 import torch.nn as nn
-from torchtyping import TensorType
-
-# Typing
-InputTensor = TensorType["batch_shape", "input_shape", float]
-OutputTensor = TensorType["batch_shape", "output_dim", float]
-
+from gfn.typing import BatchInputFloatTensor, BatchOutputFloatTensor
 
 class NeuralNet(nn.Module):
     """Implements a basic MLP."""
@@ -52,7 +47,7 @@ class NeuralNet(nn.Module):
         self.last_layer = nn.Linear(self.torso.hidden_dim, output_dim)
         self.device = None
 
-    def forward(self, preprocessed_states: InputTensor) -> OutputTensor:
+    def forward(self, preprocessed_states: BatchInputFloatTensor) -> BatchOutputFloatTensor:
         if self.device is None:
             self.device = preprocessed_states.device
             self.to(self.device)
@@ -80,7 +75,7 @@ class Tabular(nn.Module):
 
         self.device = None
 
-    def __call__(self, preprocessed_states: InputTensor) -> OutputTensor:
+    def __call__(self, preprocessed_states: BatchInputFloatTensor) -> BatchOutputFloatTensor:
         if self.device is None:
             self.device = preprocessed_states.device
             self.table = self.table.to(self.device)

--- a/src/gfn/losses/base.py
+++ b/src/gfn/losses/base.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch
-from torchtyping import TensorType
 
 from gfn.casting import correct_cast
 from gfn.containers import Trajectories, Transitions
@@ -17,10 +16,9 @@ from gfn.envs import Env
 from gfn.examples import DiscretePBEstimator, DiscretePFEstimator
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
 from gfn.states import States
-
-# Typing
-LogPTrajectoriesTensor = TensorType["max_length", "n_trajectories", float]
-ScoresTensor = TensorType["n_trajectories", float]
+from gfn.types import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
+from gfn.types import TrajectoriesFloatTensor1D as ScoresTensor
+from gfn.types import LossTensor
 
 
 @dataclass
@@ -96,19 +94,19 @@ class Loss(ABC):
         self.parametrization = parametrization
 
     @abstractmethod
-    def __call__(self, *args, **kwargs) -> TensorType[0, float]:
+    def __call__(self, *args, **kwargs) -> LossTensor:
         pass
 
 
 class EdgeDecomposableLoss(Loss, ABC):
     @abstractmethod
-    def __call__(self, edges: Transitions) -> TensorType[0, float]:
+    def __call__(self, edges: Transitions) -> LossTensor:
         pass
 
 
 class StateDecomposableLoss(Loss, ABC):
     @abstractmethod
-    def __call__(self, states_tuple: Tuple[States, States]) -> TensorType[0, float]:
+    def __call__(self, states_tuple: Tuple[States, States]) -> LossTensor:
         """Unlike the GFlowNets Foundations paper, we allow more flexibility by passing a tuple of states,
         the first one being the internal states of the trajectories (i.e. non-terminal states), and the second one
         being the terminal states of the trajectories. If these two are not handled differently, then they should be
@@ -222,5 +220,5 @@ class TrajectoryDecomposableLoss(Loss, ABC):
         )
 
     @abstractmethod
-    def __call__(self, trajectories: Trajectories) -> TensorType[0, float]:
+    def __call__(self, trajectories: Trajectories) -> LossTensor:
         pass

--- a/src/gfn/losses/base.py
+++ b/src/gfn/losses/base.py
@@ -16,9 +16,9 @@ from gfn.envs import Env
 from gfn.examples import DiscretePBEstimator, DiscretePFEstimator
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
 from gfn.states import States
-from gfn.types import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
-from gfn.types import TrajectoriesFloatTensor1D as ScoresTensor
 from gfn.types import LossTensor
+from gfn.types import TrajectoriesFloatTensor1D as ScoresTensor
+from gfn.types import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
 
 
 @dataclass

--- a/src/gfn/losses/detailed_balance.py
+++ b/src/gfn/losses/detailed_balance.py
@@ -10,10 +10,8 @@ from gfn.samplers.actions_samplers import (
     BackwardDiscreteActionsSampler,
     DiscreteActionsSampler,
 )
-
-# Typing
-ScoresTensor = TensorType["n_transitions", float]
-LossTensor = TensorType[0, float]
+from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
+from gfn.typing import LossTensor
 
 
 @dataclass

--- a/src/gfn/losses/detailed_balance.py
+++ b/src/gfn/losses/detailed_balance.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 
 import torch
-from torchtyping import TensorType
 
 from gfn.containers import Transitions
 from gfn.estimators import LogStateFlowEstimator

--- a/src/gfn/losses/detailed_balance.py
+++ b/src/gfn/losses/detailed_balance.py
@@ -9,8 +9,8 @@ from gfn.samplers.actions_samplers import (
     BackwardDiscreteActionsSampler,
     DiscreteActionsSampler,
 )
-from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
 from gfn.typing import LossTensor
+from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
 
 
 @dataclass

--- a/src/gfn/losses/detailed_balance.py
+++ b/src/gfn/losses/detailed_balance.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 import torch
+from tensortyping import TensorType as TType
 
 from gfn.containers import Transitions
 from gfn.estimators import LogStateFlowEstimator
@@ -9,8 +10,6 @@ from gfn.samplers.actions_samplers import (
     BackwardDiscreteActionsSampler,
     DiscreteActionsSampler,
 )
-from gfn.typing import LossTensor
-from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
 
 
 @dataclass
@@ -95,7 +94,7 @@ class DetailedBalance(EdgeDecomposableLoss):
 
         return (valid_log_pf_actions, log_pb_actions, scores)
 
-    def __call__(self, transitions: Transitions) -> LossTensor:
+    def __call__(self, transitions: Transitions) -> TType[0, float]:
         _, _, scores = self.get_scores(transitions)
         loss = torch.mean(scores**2)
 
@@ -104,7 +103,7 @@ class DetailedBalance(EdgeDecomposableLoss):
 
         return loss
 
-    def get_modified_scores(self, transitions: Transitions) -> ScoresTensor:
+    def get_modified_scores(self, transitions: Transitions) -> TType["n_trajectories", torch.float]:
         "DAG-GFN-style detailed balance, for when all states are connected to the sink"
         if transitions.is_backward:
             raise ValueError("Backward transitions are not supported")

--- a/src/gfn/losses/flow_matching.py
+++ b/src/gfn/losses/flow_matching.py
@@ -10,8 +10,8 @@ from gfn.estimators import LogEdgeFlowEstimator
 from gfn.losses.base import Parametrization, StateDecomposableLoss
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
 from gfn.states import States
-from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
 from gfn.typing import LossTensor
+from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
 
 
 @dataclass

--- a/src/gfn/losses/flow_matching.py
+++ b/src/gfn/losses/flow_matching.py
@@ -11,10 +11,8 @@ from gfn.estimators import LogEdgeFlowEstimator
 from gfn.losses.base import Parametrization, StateDecomposableLoss
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
 from gfn.states import States
-
-# Typing
-ScoresTensor = TensorType["n_states", float]
-LossTensor = TensorType[0, float]
+from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
+from gfn.typing import LossTensor
 
 
 @dataclass

--- a/src/gfn/losses/flow_matching.py
+++ b/src/gfn/losses/flow_matching.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch
+from tensortyping import TensorType as TType
 
 from gfn.casting import correct_cast
 from gfn.distributions import EmpiricalTrajectoryDistribution, TrajectoryDistribution
@@ -10,8 +11,7 @@ from gfn.estimators import LogEdgeFlowEstimator
 from gfn.losses.base import Parametrization, StateDecomposableLoss
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
 from gfn.states import States
-from gfn.typing import LossTensor
-from gfn.typing import TrajectoriesFloatTensor1D as ScoresTensor
+
 
 
 @dataclass
@@ -42,7 +42,7 @@ class FlowMatching(StateDecomposableLoss):
         self.env = parametrization.logF.env
         self.alpha = alpha
 
-    def flow_matching_loss(self, states: States) -> ScoresTensor:
+    def flow_matching_loss(self, states: States) -> TType["n_trajectories", torch.float]:
         """
         Compute the FM for the given states, defined as the log-sum incoming flows minus log-sum outgoing flows.
         The states should not include s0. The batch shape should be (n_states,).
@@ -100,14 +100,14 @@ class FlowMatching(StateDecomposableLoss):
 
         return (log_incoming_flows - log_outgoing_flows).pow(2).mean()
 
-    def reward_matching_loss(self, terminating_states: States) -> LossTensor:
+    def reward_matching_loss(self, terminating_states: States) -> TType[0, float]:
         assert terminating_states.log_rewards is not None
         log_edge_flows = self.parametrization.logF(terminating_states)
         terminating_log_edge_flows = log_edge_flows[:, -1]
         log_rewards = terminating_states.log_rewards
         return (terminating_log_edge_flows - log_rewards).pow(2).mean()
 
-    def __call__(self, states_tuple: Tuple[States, States]) -> LossTensor:
+    def __call__(self, states_tuple: Tuple[States, States]) -> TType[0, float]:
         intermediary_states, terminating_states = states_tuple
         fm_loss = self.flow_matching_loss(intermediary_states)
         rm_loss = self.reward_matching_loss(terminating_states)

--- a/src/gfn/losses/flow_matching.py
+++ b/src/gfn/losses/flow_matching.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Tuple
 
 import torch
-from torchtyping import TensorType
 
 from gfn.casting import correct_cast
 from gfn.distributions import EmpiricalTrajectoryDistribution, TrajectoryDistribution

--- a/src/gfn/losses/sub_trajectory_balance.py
+++ b/src/gfn/losses/sub_trajectory_balance.py
@@ -12,8 +12,8 @@ from gfn.typing import LossTensor
 from gfn.typing import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
 
 # Typing
-ScoresTensor = TensorType[-1, float]  # TODO: What does -1 mean here? Is it 
-                                      #       equivilant to 0?
+ScoresTensor = TensorType[-1, float]  # TODO: What does -1 mean here? Is it
+#       equivilant to 0?
 
 
 @dataclass

--- a/src/gfn/losses/sub_trajectory_balance.py
+++ b/src/gfn/losses/sub_trajectory_balance.py
@@ -9,10 +9,11 @@ from gfn.estimators import LogStateFlowEstimator
 from gfn.losses.base import PFBasedParametrization, TrajectoryDecomposableLoss
 from gfn.samplers import BackwardDiscreteActionsSampler, DiscreteActionsSampler
 from gfn.typing import LossTensor
+from gfn.typing import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
 
 # Typing
-ScoresTensor = TensorType[-1, float]
-LogPTrajectoriesTensor = TensorType["max_length", "n_trajectories", float]
+ScoresTensor = TensorType[-1, float]  # TODO: What does -1 mean here? Is it 
+                                      #       equivilant to 0?
 
 
 @dataclass

--- a/src/gfn/losses/sub_trajectory_balance.py
+++ b/src/gfn/losses/sub_trajectory_balance.py
@@ -2,18 +2,12 @@ from dataclasses import dataclass
 from typing import List, Literal, Tuple
 
 import torch
-from torchtyping import TensorType
+from tensortyping import TensorType as TType
 
 from gfn.containers import Trajectories
 from gfn.estimators import LogStateFlowEstimator
 from gfn.losses.base import PFBasedParametrization, TrajectoryDecomposableLoss
 from gfn.samplers import BackwardDiscreteActionsSampler, DiscreteActionsSampler
-from gfn.typing import LossTensor
-from gfn.typing import TrajectoriesFloatTensor2D as LogPTrajectoriesTensor
-
-# Typing
-ScoresTensor = TensorType[-1, float]  # TODO: What does -1 mean here? Is it
-#       equivilant to 0?
 
 
 @dataclass
@@ -73,8 +67,8 @@ class SubTrajectoryBalance(TrajectoryDecomposableLoss):
     def cumulative_logprobs(
         self,
         trajectories: Trajectories,
-        log_p_trajectories: LogPTrajectoriesTensor,
-    ) -> LogPTrajectoriesTensor:
+        log_p_trajectories: TType["max_length", "n_trajectories", torch.float],
+    ) -> TType["max_length", "n_trajectories", torch.float]:
         """
         :param trajectories: trajectories
         :param log_p_trajectories: log probabilities of each transition in each trajectory
@@ -92,7 +86,7 @@ class SubTrajectoryBalance(TrajectoryDecomposableLoss):
 
     def get_scores(
         self, trajectories: Trajectories
-    ) -> Tuple[List[ScoresTensor], List[ScoresTensor]]:
+    ) -> Tuple[List[TType[-1, float]], List[TType[-1, float]]]:  # TODO: why -1 here? Is it equivilant to 0?
         """
         Returns two elements:
         - A list of tensors, each of which representing the scores of all sub-trajectories of length k, for k in [1, ..., trajectories.max_length].
@@ -177,7 +171,7 @@ class SubTrajectoryBalance(TrajectoryDecomposableLoss):
             flattening_masks,
         )
 
-    def __call__(self, trajectories: Trajectories) -> LossTensor:
+    def __call__(self, trajectories: Trajectories) -> TType[0, float]:
         (
             scores,
             flattening_masks,

--- a/src/gfn/losses/trajectory_balance.py
+++ b/src/gfn/losses/trajectory_balance.py
@@ -5,7 +5,6 @@ and the [Log Partition Variance loss](https://arxiv.org/abs/2302.05446).
 from dataclasses import dataclass
 
 import torch
-from torchtyping import TensorType
 
 from gfn.containers import Trajectories
 from gfn.estimators import LogZEstimator

--- a/src/gfn/losses/trajectory_balance.py
+++ b/src/gfn/losses/trajectory_balance.py
@@ -5,12 +5,12 @@ and the [Log Partition Variance loss](https://arxiv.org/abs/2302.05446).
 from dataclasses import dataclass
 
 import torch
+from tensortyping import TensorType as TType
 
 from gfn.containers import Trajectories
 from gfn.estimators import LogZEstimator
 from gfn.losses.base import PFBasedParametrization, TrajectoryDecomposableLoss
 from gfn.samplers import BackwardDiscreteActionsSampler, DiscreteActionsSampler
-from gfn.typing import LossTensor
 
 
 @dataclass
@@ -48,7 +48,7 @@ class TrajectoryBalance(TrajectoryDecomposableLoss):
         )
         self.on_policy = on_policy
 
-    def __call__(self, trajectories: Trajectories) -> LossTensor:
+    def __call__(self, trajectories: Trajectories) -> TType[0, float]:
         _, _, scores = self.get_trajectories_scores(trajectories)
         loss = (scores + self.parametrization.logZ.tensor).pow(2).mean()
         if torch.isnan(loss):
@@ -80,7 +80,7 @@ class LogPartitionVarianceLoss(TrajectoryDecomposableLoss):
 
         self.on_policy = on_policy
 
-    def __call__(self, trajectories: Trajectories) -> LossTensor:
+    def __call__(self, trajectories: Trajectories) -> TType[0, float]:
         _, _, scores = self.get_trajectories_scores(trajectories)
         loss = (scores - scores.mean()).pow(2).mean()
         if torch.isnan(loss):

--- a/src/gfn/samplers/actions_samplers.py
+++ b/src/gfn/samplers/actions_samplers.py
@@ -9,7 +9,7 @@ from gfn.casting import correct_cast
 from gfn.estimators import LogEdgeFlowEstimator, ProbabilityEstimator
 from gfn.examples import DiscretePBEstimator, DiscretePFEstimator
 from gfn.states import States
-from gfn.transitions import BatchLongTensor, BatchFloatTensor, BatchActionsTensor
+from gfn.transitions import BatchActionsTensor, BatchFloatTensor, BatchLongTensor
 
 
 class ActionsSampler:

--- a/src/gfn/samplers/actions_samplers.py
+++ b/src/gfn/samplers/actions_samplers.py
@@ -3,19 +3,13 @@ from typing import Tuple
 
 import torch
 from torch.distributions import Categorical
-from torchtyping import TensorType
 
 from gfn.actions import Actions
 from gfn.casting import correct_cast
 from gfn.estimators import LogEdgeFlowEstimator, ProbabilityEstimator
 from gfn.examples import DiscretePBEstimator, DiscretePFEstimator
 from gfn.states import States
-
-# Typing
-Tensor2D = TensorType["batch_size", "n_actions"]
-Tensor2D2 = TensorType["batch_size", "n_steps"]
-Tensor1D = TensorType["batch_size", torch.long]
-LogProbsTensor = TensorType["batch_shape", torch.float]
+from gfn.transitions import BatchLongTensor, BatchFloatTensor, BatchActionsTensor
 
 
 class ActionsSampler:
@@ -25,14 +19,14 @@ class ActionsSampler:
         self.estimator = estimator
         self.env = estimator.env
 
-    def sample(self, states: States) -> Tuple[Actions, LogProbsTensor]:
+    def sample(self, states: States) -> Tuple[Actions, BatchFloatTensor]:
         """Samples actions from the given states.
 
         Args:
             states (States): A batch of states.
 
         Returns:
-            Tuple[Actions, LogProbsTensor]: A tuple of tensors:
+            Tuple[Actions, BatchFloatTensor]: A tuple of tensors:
              - An Actions object containing the sampled actions.
              - A tensor of shape (*batch_shape,) containing the log probabilities of the sampled actions under
                 the probability distribution of the given states.
@@ -52,7 +46,7 @@ class ActionsSampler:
 #     """
 
 #     @abstractmethod
-#     def sample(self, states: States) -> Tuple[Tensor1D, Tensor1D]:
+#     def sample(self, states: States) -> Tuple[BatchLongTensor, BatchLongTensor]:
 #         """
 #         Args:
 #             states (States): A batch of states.
@@ -95,25 +89,25 @@ class ActionsSampler:
 #         self.sf_bias = sf_bias
 #         self.epsilon = epsilon
 
-#     def get_raw_logits(self, states: States) -> Tensor2D:
+#     def get_raw_logits(self, states: States) -> TensorBatchActions:
 #         """
 #         This is before illegal actions are masked out and the exit action is biased.
 #         Should be used for Discrete action spaces only.
 
 #         Returns:
-#             Tensor2D: A 2D tensor of shape (batch_size, n_actions) containing the logits for each action in each state in the batch.
+#             BatchActionsTensor: A 2D tensor of shape (batch_size, n_actions) containing the logits for each action in each state in the batch.
 #         """
 #         logits = self.estimator(states)
 #         return logits
 
-#     def get_logits(self, states: States) -> Tensor2D:
+#     def get_logits(self, states: States) -> BatchActionsTensor:
 #         """Transforms the raw logits by masking illegal actions.
 
 #         Raises:
 #             ValueError: if one of the resulting logits is NaN.
 
 #         Returns:
-#             Tensor2D: A 2D tensor of shape (batch_size, n_actions) containing the transformed logits.
+#             BatchActionsTensor: A 2D tensor of shape (batch_size, n_actions) containing the transformed logits.
 #         """
 #         logits = self.get_raw_logits(states)
 
@@ -128,7 +122,7 @@ class ActionsSampler:
 #     def get_probs(
 #         self,
 #         states: States,
-#     ) -> Tensor2D:
+#     ) -> BatchActionsTensor:
 #         """
 #         Returns:
 #             The probabilities of each action in each state in the batch.
@@ -138,7 +132,7 @@ class ActionsSampler:
 #         probs = torch.softmax(logits / self.temperature, dim=-1)
 #         return probs
 
-#     def sample(self, states: States) -> Tuple[Tensor1D, Tensor1D]:
+#     def sample(self, states: States) -> Tuple[BatchLongTensor, BatchLongTensor]:
 #         probs = self.get_probs(states)
 #         states.forward_masks, _ = correct_cast(
 #             states.forward_masks, states.backward_masks
@@ -173,7 +167,7 @@ class ActionsSampler:
 #             estimator, temperature=temperature, sf_bias=0.0, epsilon=epsilon
 #         )
 
-#     def get_logits(self, states: States) -> Tensor2D:
+#     def get_logits(self, states: States) -> BatchActionsTensor:
 #         logits = self.get_raw_logits(states)
 #         if torch.any(torch.all(torch.isnan(logits), 1)):
 #             raise ValueError("NaNs in estimator")
@@ -183,7 +177,7 @@ class ActionsSampler:
 #         logits[~states.backward_masks] = -float("inf")
 #         return logits
 
-#     def get_probs(self, states: States) -> Tensor2D:
+#     def get_probs(self, states: States) -> BatchActionsTensor:
 #         logits = self.get_logits(states)
 #         probs = torch.softmax(logits / self.temperature, dim=-1)
 #         # The following line is hack that works: when probs are nan, it means

--- a/src/gfn/samplers/trajectories_sampler.py
+++ b/src/gfn/samplers/trajectories_sampler.py
@@ -60,11 +60,11 @@ class TrajectoriesSampler:
             ), "States should be a linear batch of states"
             n_trajectories = states.batch_shape[0]
 
-        device = states.states_tensor.device
+        device = states.tensor.device
 
         dones = states.is_initial_state if self.is_backward else states.is_sink_state
 
-        trajectories_states: List[StatesTensor] = [states.states_tensor]
+        trajectories_states: List[StatesTensor] = [states.tensor]
         trajectories_actions: List[ActionsTensor] = []
         trajectories_logprobs: List[LogProbsTensor] = []
         trajectories_dones = torch.zeros(
@@ -119,7 +119,7 @@ class TrajectoriesSampler:
             states = new_states
             dones = dones | new_dones
 
-            trajectories_states += [states.states_tensor]
+            trajectories_states += [states.tensor]
 
         trajectories_states = torch.stack(trajectories_states, dim=0)
         trajectories_states = self.env.States(states_tensor=trajectories_states)

--- a/src/gfn/samplers/trajectories_sampler.py
+++ b/src/gfn/samplers/trajectories_sampler.py
@@ -1,18 +1,15 @@
 from typing import List, Optional
 
 import torch
-from torchtyping import TensorType
 
 from gfn.containers import Trajectories
 from gfn.envs import Env
 from gfn.samplers import ActionsSampler, BackwardActionsSampler
 from gfn.states import States
-
-# Typing
-StatesTensor = TensorType["n_trajectories", "state_shape", torch.float]
-ActionsTensor = TensorType["n_trajectories", torch.long]
-LogProbsTensor = TensorType["n_trajectories", torch.float]
-DonesTensor = TensorType["n_trajectories", torch.bool]
+from gfn.typing import TrajectoriesStatesTensor
+from gfn.typing import TrajectoriesLongTensor1D as ActionsTensor
+from gfn.typing import TrajectoriesFloatTensor1D as LogProbsTensor
+from gfn.typing import TrajectoriesBoolTensor1D as DonesTensor
 
 
 class TrajectoriesSampler:
@@ -64,7 +61,7 @@ class TrajectoriesSampler:
 
         dones = states.is_initial_state if self.is_backward else states.is_sink_state
 
-        trajectories_states: List[StatesTensor] = [states.tensor]
+        trajectories_states: List[TrajectoriesStatesTensor] = [states.tensor]
         trajectories_actions: List[ActionsTensor] = []
         trajectories_logprobs: List[LogProbsTensor] = []
         trajectories_dones = torch.zeros(

--- a/src/gfn/samplers/trajectories_sampler.py
+++ b/src/gfn/samplers/trajectories_sampler.py
@@ -6,10 +6,10 @@ from gfn.containers import Trajectories
 from gfn.envs import Env
 from gfn.samplers import ActionsSampler, BackwardActionsSampler
 from gfn.states import States
-from gfn.typing import TrajectoriesStatesTensor
-from gfn.typing import TrajectoriesLongTensor1D as ActionsTensor
-from gfn.typing import TrajectoriesFloatTensor1D as LogProbsTensor
 from gfn.typing import TrajectoriesBoolTensor1D as DonesTensor
+from gfn.typing import TrajectoriesFloatTensor1D as LogProbsTensor
+from gfn.typing import TrajectoriesLongTensor1D as ActionsTensor
+from gfn.typing import TrajectoriesStatesTensor
 
 
 class TrajectoriesSampler:

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -6,14 +6,10 @@ from typing import ClassVar, Optional, Sequence, cast
 
 import torch
 
-from gfn.typing import (
-    ForwardMasksTensor, 
-    BackwardMasksTensor, 
-    StatesFloatTensor, 
-    OneStateTensor
-)
+from gfn.typing import BackwardMasksTensor
 from gfn.typing import BatchBoolTensor as DonesTensor
 from gfn.typing import BatchFloatTensor as RewardsTensor
+from gfn.typing import ForwardMasksTensor, OneStateTensor, StatesFloatTensor
 
 
 class States(ABC):

--- a/src/gfn/states.py
+++ b/src/gfn/states.py
@@ -263,9 +263,12 @@ class DiscreteStates(States, ABC):
         """
         pass
 
+    def _check_both_forward_backward_masks_exist(self):
+        assert self.forward_masks is not None and self.backward_masks is not None
+
     def __getitem__(self, index: int | Sequence[int] | Sequence[bool]) -> States:
         states = self.tensor[index]
-        assert self.forward_masks is not None and self.backward_masks is not None
+        self._check_both_forward_backward_masks_exist()
         forward_masks = self.forward_masks[index]
         backward_masks = self.backward_masks[index]
         return self.__class__(states, forward_masks, backward_masks)
@@ -274,13 +277,13 @@ class DiscreteStates(States, ABC):
         self, index: int | Sequence[int] | Sequence[bool], states: States
     ) -> None:
         super().__setitem__(index, states)
-        assert self.forward_masks is not None and self.backward_masks is not None
+        self._check_both_forward_backward_masks_exist()
         self.forward_masks[index] = states.forward_masks
         self.backward_masks[index] = states.backward_masks
 
     def flatten(self) -> States:
         states = self.tensor.view(-1, *self.state_shape)
-        assert self.forward_masks is not None and self.backward_masks is not None
+        self._check_both_forward_backward_masks_exist()
         forward_masks = self.forward_masks.view(-1, self.forward_masks.shape[-1])
         backward_masks = self.backward_masks.view(-1, self.backward_masks.shape[-1])
         return self.__class__(states, forward_masks, backward_masks)

--- a/src/gfn/typing.py
+++ b/src/gfn/typing.py
@@ -1,5 +1,5 @@
-from torchtyping import TensorType
 import torch
+from torchtyping import TensorType
 
 # Types specific to the handling of actions masking.
 ForwardMasksTensor = TensorType["batch_shape", "n_actions", torch.bool]
@@ -29,8 +29,10 @@ BatchActionsTensor = TensorType["batch_shape", "action_shape"]
 BatchStepsTensor = TensorType["batch_size", "n_steps"]  # TODO: remove? unusued?
 
 # Types specific to environment preprocessing.
-BatchInputTensor = TensorType["batch_shape", "input_dim"]  # Note: Should we specify precision?
-BatchInputFloatTensor = TensorType["batch_shape", "input_dim", float]  
+BatchInputTensor = TensorType[
+    "batch_shape", "input_dim"
+]  # Note: Should we specify precision?
+BatchInputFloatTensor = TensorType["batch_shape", "input_dim", float]
 BatchOutputFloatTensor = TensorType["batch_shape", "output_dim", float]
 
 # Types specific to handling single states/actions.
@@ -50,9 +52,9 @@ TrajectoriesFloatTensor2D = TensorType["max_length", "n_trajectories", torch.flo
 TrajectoriesLongTensor2D = TensorType["max_length", "n_trajectories", torch.long]
 
 # To Remove:
-#TrajectoriesTensor2D2 = TensorType["n_trajectories", "shape"]
-#TrajectoriesTensor1D = TensorType["n_trajectories", torch.long]
-#TrajectoriesFloatTensor1D = TensorType["n_trajectories", torch.float]
+# TrajectoriesTensor2D2 = TensorType["n_trajectories", "shape"]
+# TrajectoriesTensor1D = TensorType["n_trajectories", torch.long]
+# TrajectoriesFloatTensor1D = TensorType["n_trajectories", torch.float]
 
-#Tensor2D = TensorType["max_length", "n_trajectories", torch.long]
-#Tensor2D2 = TensorType["n_trajectories", "shape"]
+# Tensor2D = TensorType["max_length", "n_trajectories", torch.long]
+# Tensor2D2 = TensorType["n_trajectories", "shape"]

--- a/src/gfn/typing.py
+++ b/src/gfn/typing.py
@@ -1,0 +1,58 @@
+from torchtyping import TensorType
+import torch
+
+# Types specific to the handling of actions masking.
+ForwardMasksTensor = TensorType["batch_shape", "n_actions", torch.bool]
+BackwardMasksTensor = TensorType["batch_shape", "n_actions - 1", torch.bool]
+
+# Types specific to handling a batch of states.
+StatesFloatTensor = TensorType["batch_shape", "state_shape", torch.float]
+StatesBoolTensor = TensorType["batch_shape", "state_shape", torch.bool]
+StatesShortTensor = TensorType["batch_shape", "state_shape", torch.short]
+StatesLongTensor = TensorType["batch_shape", "state_shape", torch.long]
+
+# Types specific to handling a bactch of scalars (e.g., rewards, flows).
+BatchFloatTensor = TensorType["batch_shape", torch.float]
+BatchBoolTensor = TensorType["batch_shape", torch.bool]
+BatchShortTensor = TensorType["batch_shape", torch.short]
+BatchLongTensor = TensorType["batch_shape", torch.long]
+BatchGenericTensor = TensorType["batch_shape"]
+
+# Types specific to transitions, n_transitions is either int or Tuple[int].
+TransitionLongTensor = TensorType["n_transitions", torch.long]
+TransitionBoolTensor = TensorType["n_transitions", torch.bool]
+TransitionFloatTensor = TensorType["n_transitions", torch.float]
+TransitionPairFloatTensor = TensorType["n_transitions", 2, torch.float]
+
+# Types specific to handling a batch of actions or steps.
+BatchActionsTensor = TensorType["batch_shape", "action_shape"]
+BatchStepsTensor = TensorType["batch_size", "n_steps"]  # TODO: remove? unusued?
+
+# Types specific to environment preprocessing.
+BatchInputTensor = TensorType["batch_shape", "input_dim"]  # Note: Should we specify precision?
+BatchInputFloatTensor = TensorType["batch_shape", "input_dim", float]  
+BatchOutputFloatTensor = TensorType["batch_shape", "output_dim", float]
+
+# Types specific to handling single states/actions.
+OneStateTensor = TensorType["state_shape", torch.float]
+OneActionTensor = TensorType["action_shape"]
+
+# Types specific to handling distributions, losses, etc.
+PmfTensor = TensorType["n_states", torch.float]
+LossTensor = TensorType[0, float]  # TODO: Rename to ScalarTensor.
+
+# Types specific to transitions. n_transitions is an int.
+TrajectoriesBoolTensor1D = TensorType["n_trajectories", torch.bool]
+TrajectoriesFloatTensor1D = TensorType["n_trajectories", torch.float]
+TrajectoriesLongTensor1D = TensorType["n_trajectories", torch.long]
+TrajectoriesStatesTensor = TensorType["n_trajectories", "state_shape", torch.float]
+TrajectoriesFloatTensor2D = TensorType["max_length", "n_trajectories", torch.float]
+TrajectoriesLongTensor2D = TensorType["max_length", "n_trajectories", torch.long]
+
+# To Remove:
+#TrajectoriesTensor2D2 = TensorType["n_trajectories", "shape"]
+#TrajectoriesTensor1D = TensorType["n_trajectories", torch.long]
+#TrajectoriesFloatTensor1D = TensorType["n_trajectories", torch.float]
+
+#Tensor2D = TensorType["max_length", "n_trajectories", torch.long]
+#Tensor2D2 = TensorType["n_trajectories", "shape"]

--- a/testing/test_environments.py
+++ b/testing/test_environments.py
@@ -244,7 +244,7 @@ def test_box_fwd_step(delta: float):
 
         actions = format_actions(format_tensor(actions_list, discrete=False), env)
         states = env.step(states, actions)
-        states_tensor = states.states_tensor
+        states_tensor = states.tensor
 
         # The following evaluate the maximum angles of the possible actions
         A = torch.where(
@@ -280,7 +280,7 @@ def test_states_getitem(ndim: int, env_name: str):
     n_selections = int(torch.sum(selections))
     selected_states = states[selections]
 
-    assert selected_states.states_tensor.shape == (
+    assert selected_states.tensor.shape == (
         n_selections,
         ndim if env_name != "Box" else 2,
     )
@@ -290,7 +290,7 @@ def test_states_getitem(ndim: int, env_name: str):
     n_selections = int(torch.sum(selections))
     selected_states = states[selections]
 
-    assert selected_states.states_tensor.shape == (
+    assert selected_states.tensor.shape == (
         n_selections,
         ND_BATCH_SHAPE[1],
         ndim if env_name != "Box" else 2,


### PR DESCRIPTION
+ `typing.py` now contains a set of generic types. I haven't settled on the minimal set (I'm still not sure how important having all the different string identifiers for dimensions is), so I this version is likely too verbose.
    + e.g.,  `BackwardMasksTensor`, `BatchBoolTensor`, `TransitionFloatTensor`, `OneActionTensor`.
+ When you want named types in your code, one possibility is the following:

```
from gfn.typing import TrajectoriesStatesTensor
from gfn.typing import TrajectoriesLongTensor1D as ActionsTensor
from gfn.typing import TrajectoriesFloatTensor1D as LogProbsTensor
from gfn.typing import TrajectoriesBoolTensor1D as DonesTensor
```

+ This is cosmetic and I'm not sure whether it's good practice or not. I would prefer not renaming but it hurts readability so I'm leaving it here for discussion.

Pros of this approach:

+ Don't repeat yourself. In particular the same kind of tensor has multiple names across different files. This makes the codebase a little more confusing and will likely get worse with time.
+ Easier to understand which types are actually being used (linters throw shade at unused imports).
+ Helps us converge on a minimal set of types that handle all GFN use cases -- I.e., we are encouraged to keep `typing.py` small.

Cons:

+ Some of these names are pretty long.
+ Not immediately clear that this file won't expand to infinity.
+ You might need to reference the `typing.py` file to remind yourself what this type represents. 

TODO:

- [ ] Removing all typing mentions from docstrings.
- [ ] Converge on minimal set of types.
- [ ] Resolve outstanding TODOs in `typing.py`.
- [ ] Remove unused references.
- [ ] Explore alternative methods for tracking tensor dimensions without relying on docstrings.