### PR TITLE
Use yaml configs instead of simple parsing

### DIFF
--- a/src/gfn/__init__.py
+++ b/src/gfn/__init__.py
@@ -5,3 +5,7 @@ from .estimators import (
     LogStateFlowEstimator,
     LogZEstimator,
 )
+
+import importlib.metadata as met
+
+__version__ = met.version("gfn")


### PR DESCRIPTION
Parsing is now handled by `scripts/configs/parser.py`

The workflow is:

* Parser args
	* Built-in
		* Config namespaces `--env`, `--loss`, `--sampler`, `--optim` will be used to load yaml files
		* Other args
	* Overrides
		* Any config value can be overwritten from the CLI e.g. `--env.R2=2`
* Load name spaces
	* In `scripts/configs/` sit 4 folders `env/`, `loss/`, `sampler/` and `optim/`
	* Their `base.yaml` will always be loaded, always first
	* IFF a value is passed to the associated CLI arg, `scripts/configs/{namespace}/{value}.yaml` will be loaded
* The CLI overriding arguments are set _after_ those namespaces so they have a higher priority

Note: `yaml` does not parse `1e-3` as a number, it will be considered a string, so prefer `0.001` (if you change a _file_, it's fine from the CLI)