### PR TITLE
Extending trajectories that are on a gpu device

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
             (?x)^(
                 .*\.ipynb
             )$
-  - repo: https://gitlab.com/PyCQA/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
       - id: flake8
@@ -30,7 +30,7 @@ repos:
           - --show-source
           - --statistics
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.11.5
     hooks:
       - id: isort
         args: ["--profile", "black"]

--- a/scripts/configs/__init__.py
+++ b/scripts/configs/__init__.py
@@ -1,5 +1,5 @@
 from .env import make_env
 from .loss import make_loss
 from .optim import make_optim
-from .sampler import make_sampler
 from .parser import load_config
+from .sampler import make_sampler

--- a/scripts/configs/env.py
+++ b/scripts/configs/env.py
@@ -55,7 +55,7 @@ def make_env(config: dict) -> Env:
     elif name.lower() == "discrete-ebm".lower():
         env_class = DiscreteEBMConfig
     else:
-        raise ValueError("Invalid env name: {}".format(name))
+        raise ValueError(f"Invalid env name: {name}")
 
     args = inspect.getfullargspec(env_class.__init__).args
     env_config = {k: v for k, v in config["env"].items() if k in args}

--- a/scripts/configs/loss.py
+++ b/scripts/configs/loss.py
@@ -1,7 +1,7 @@
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import Tuple, Literal
-import inspect
+from typing import Literal, Tuple
 
 import torch
 
@@ -200,7 +200,7 @@ def make_loss(config: dict, env: Env) -> Tuple[Parametrization, Loss]:
     elif name.lower() == "sub-tb".lower():
         loss_class = SubTBLossConfig
     else:
-        raise ValueError("Invalid loss name: {}".format(name))
+        raise ValueError(f"Invalid loss name: {name}")
 
     args = inspect.getfullargspec(loss_class.__init__).args
     loss_config = {k: v for k, v in config["loss"].items() if k in args}

--- a/scripts/configs/optim.py
+++ b/scripts/configs/optim.py
@@ -1,7 +1,8 @@
+import inspect
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple
-import inspect
+
 import torch
 
 from gfn.losses import Parametrization
@@ -25,7 +26,7 @@ class BaseOptimConfig(ABC):
                 "lr": self.lr,
             }
         ]
-        if any(["logZ" in p for p in  parametrization.parameters.keys()]):
+        if any(["logZ" in p for p in parametrization.parameters.keys()]):
             params.append(
                 {
                     "params": [
@@ -79,7 +80,7 @@ def make_optim(config: dict, parametrization: Parametrization) -> torch.optim.Op
     elif name.lower() == "adam".lower():
         optim_class = AdamConfig
     else:
-        raise ValueError("Invalid optim name: {}".format(name))
+        raise ValueError(f"Invalid optim name: {name}")
 
     args = inspect.getfullargspec(optim_class.__init__).args
     optim_config = {k: v for k, v in config["optim"].items() if k in args}

--- a/scripts/configs/parser.py
+++ b/scripts/configs/parser.py
@@ -113,7 +113,7 @@ def create_dict_from_args(args: list, sep: str = "."):
 
 def parse_args_to_dict(parser: ArgumentParser) -> Tuple[dict, dict]:
     """
-    Parse default arguments in a dictionnary,
+    Parse default arguments in a dictionary,
     and arbitrary extra command line arguments to another dictionary.
 
         Returns:
@@ -169,7 +169,7 @@ def load_config(parser: ArgumentParser) -> dict:
         dict: GFlowNet run config
     """
     config, cli = parse_args_to_dict(parser)
-    namespaces = set(b.parent.name for b in Path(__file__).parent.glob("*/base.yaml"))
+    namespaces = {b.parent.name for b in Path(__file__).parent.glob("*/base.yaml")}
     for namespace in namespaces:
         value = config.get(namespace.replace(".yaml", ""))
         config[namespace] = load_named_config(namespace, value)

--- a/scripts/configs/sampler.py
+++ b/scripts/configs/sampler.py
@@ -1,7 +1,7 @@
+import inspect
 from dataclasses import dataclass
 from typing import Tuple
 
-import inspect
 from gfn.envs import Env
 from gfn.losses import FMParametrization, Parametrization, PFBasedParametrization
 from gfn.samplers import DiscreteActionsSampler, TrajectoriesSampler
@@ -48,7 +48,7 @@ def make_sampler(
     if not name:
         sampler_class = SamplerConfig
     else:
-        raise ValueError("Invalid sampler name: {}".format(name))
+        raise ValueError(f"Invalid sampler name: {name}")
 
     args = inspect.getfullargspec(sampler_class.__init__).args
     sampler_config = {k: v for k, v in config["sampler"].items() if k in args}

--- a/src/gfn/__init__.py
+++ b/src/gfn/__init__.py
@@ -1,3 +1,5 @@
+import importlib.metadata as met
+
 from .estimators import (
     LogEdgeFlowEstimator,
     LogitPBEstimator,
@@ -5,7 +7,5 @@ from .estimators import (
     LogStateFlowEstimator,
     LogZEstimator,
 )
-
-import importlib.metadata as met
 
 __version__ = met.version("torchgfn")

--- a/src/gfn/containers/trajectories.py
+++ b/src/gfn/containers/trajectories.py
@@ -184,7 +184,7 @@ class Trajectories(Container):
                     ),
                     fill_value=-1,
                     dtype=torch.long,
-                ),
+                ).to(self.actions.device),
             ),
             dim=0,
         )
@@ -198,7 +198,7 @@ class Trajectories(Container):
                     ),
                     fill_value=0,
                     dtype=torch.float,
-                ),
+                ).to(self.log_probs.device),
             ),
             dim=0,
         )

--- a/testing/test_samplers.py
+++ b/testing/test_samplers.py
@@ -177,3 +177,46 @@ def test_replay_buffer(
     print(
         f"After adding {len(training_objects)} trajectories, the replay buffer is {replay_buffer} \n {replay_buffer.training_objects}  "
     )
+
+
+def test_extend_trajectories_on_cuda():
+    import os
+    import sys
+
+    sys.path.insert(0, os.path.abspath("__file__" + "/../"))
+
+    from src.gfn.containers.trajectories import Trajectories as Traj
+
+    torch.manual_seed(0)
+
+    env = HyperGrid(ndim=4, height=8, R0=0.01, device_str="cuda")
+    sampler = TrajectoriesSampler(
+        env=env,
+        actions_sampler=DiscreteActionsSampler(
+            estimator=LogitPFEstimator(env=env, module_name="NeuralNet"),
+        ),
+    )
+
+    trajectories_1 = sampler.sample(n_trajectories=10)
+    trajectories_2 = sampler.sample(n_trajectories=10)
+
+    trajectories_1 = Traj(
+        env=sampler.env,
+        states=trajectories_1.states,
+        actions=trajectories_1.actions,
+        when_is_done=trajectories_1.when_is_done,
+        is_backward=sampler.is_backward,
+        log_rewards=trajectories_1.log_rewards,
+        log_probs=trajectories_1.log_probs,
+    )
+    trajectories_2 = Traj(
+        env=sampler.env,
+        states=trajectories_2.states,
+        actions=trajectories_2.actions,
+        when_is_done=trajectories_2.when_is_done,
+        is_backward=sampler.is_backward,
+        log_rewards=trajectories_2.log_rewards,
+        log_probs=trajectories_2.log_probs,
+    )
+
+    trajectories_1.extend(trajectories_2)


### PR DESCRIPTION
An error occurs when combining two trajectories on gpu using `extend()`. Specifically, when `extend_actions()` tries to pad the `actions` from the trajectories, the padding created is on cpu. So, when `torch.cat()` is called, we get the error:

```python
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
``` 
Presumably, the same will be true for the `log_probs`.

The main change of this PR is putting the paddings for `actions` and `log_probs` on the same device. The test for this change is on `test_extend_trajectories_on_cuda()`.

**Notes:**
- There were some errors in the initial pre-commit involving `flake8` (not found in gitlab) and `isort` (invalid Poetry configuration). I can remove the changes in `pre-commit-config.yaml` in this PR if needed
-  Other file changes are from running `pre-commit`
- The files imported in the tests are located in an external site packages library for my conda environment. So they will not reflect my changes. Instead, I tried to manually import the relevant class in the modified file. Maybe there's a setting during installation so that the imports directly point to the files tracked by git? Do you have other suggestions for this?

Thank you very much!