### PR TITLE
Simplification of `SubTBGFlowNet.loss` and `SubTBGFlowNet.get_scores`

### DIFF
--- a/src/gfn/gflownet/sub_trajectory_balance.py
+++ b/src/gfn/gflownet/sub_trajectory_balance.py
@@ -181,7 +181,9 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
         return log_state_flows
 
     def calculate_masks(
-        self, log_state_flows: TT, trajectories: Trajectories
+        self,
+        log_state_flows: TT["max_length", "n_trajectories"],
+        trajectories: Trajectories,
     ) -> Tuple[
         TT["max_length", "n_trajectories"],
         TT["max_length", "n_trajectories"],

--- a/src/gfn/gflownet/sub_trajectory_balance.py
+++ b/src/gfn/gflownet/sub_trajectory_balance.py
@@ -313,14 +313,6 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
     def get_modified_db_contributions(self, trajectories: Trajectories) -> TT:
         """
         Calculates contributions for the 'ModifiedDB' weighting method.
-
-        Args:
-            is_done: Tensor representing when each trajectory is done.
-            n_rows: Number of rows in the all_scores tensor.
-            n_trajectories: Number of trajectories.
-
-        Returns:
-            contributions: Tensor of calculated contributions.
         """
         is_done = trajectories.when_is_done
         max_len = trajectories.max_length
@@ -344,15 +336,6 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
     def get_geometric_within_contributions(self, trajectories: Trajectories) -> TT:
         """
         Calculates contributions for the 'geometric_within' weighting method.
-
-        Args:
-            is_done: Tensor representing when each trajectory is done.
-            n_rows: Number of rows in the all_scores tensor.
-            n_trajectories: Number of trajectories.
-            lamda: Lambda factor for geometric series.
-
-        Returns:
-            contributions: Tensor of calculated contributions.
         """
         L = self.lamda
         max_len = trajectories.max_length

--- a/src/gfn/gflownet/sub_trajectory_balance.py
+++ b/src/gfn/gflownet/sub_trajectory_balance.py
@@ -91,6 +91,105 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
             dim=0,
         )
 
+    def calculate_preds(
+        self,
+        log_pf_trajectories_cum: TT,
+        log_state_flows: TT,
+        i: int,
+    ) -> TT:
+        """
+        Calculate the predictions tensor for the current sub-trajectory length.
+        """
+        current_log_state_flows = (
+            log_state_flows if i == 1 else log_state_flows[: -(i - 1)]
+        )
+
+        preds = (
+            log_pf_trajectories_cum[i:]
+            - log_pf_trajectories_cum[:-i]
+            + current_log_state_flows
+        )
+
+        return preds
+
+    def calculate_targets(
+        self,
+        trajectories: Trajectories,
+        preds: TT,
+        log_pb_trajectories_cum: TT,
+        log_state_flows: TT,
+        is_terminal_mask: TT,
+        sink_states_mask: TT,
+        full_mask: TT,
+        i: int,
+    ) -> TT:
+        """
+        Calculate the targets tensor for the current sub-trajectory length.
+        """
+        targets = torch.full_like(preds, fill_value=-float("inf"))
+        assert trajectories.log_rewards is not None
+        log_rewards = trajectories.log_rewards[
+            trajectories.when_is_done >= i
+        ].clamp_min(self.log_reward_clip_min)
+        targets.T[is_terminal_mask[i - 1 :].T] = log_rewards
+
+        # For now, the targets contain the log-rewards of the ending sub trajectories
+        # We need to add to that the log-probabilities of the backward actions up-to
+        # the sub-trajectory's terminating state
+        if i > 1:
+            targets[is_terminal_mask[i - 1 :]] += (
+                log_pb_trajectories_cum[i - 1 :] - log_pb_trajectories_cum[: -i + 1]
+            )[:-1][is_terminal_mask[i - 1 :]]
+
+        # The following creates the targets for the non-finishing sub-trajectories
+        targets[~full_mask[i - 1 :]] = (
+            log_pb_trajectories_cum[i:] - log_pb_trajectories_cum[:-i]
+        )[:-1][~full_mask[i - 1 : -1]] + log_state_flows[i:][~sink_states_mask[i:]]
+
+        return targets
+
+    def calculate_log_state_flows(
+        self,
+        env: Env,
+        trajectories: Trajectories,
+        log_pf_trajectories: TT,
+    ) -> TT:
+        """
+        Calculate log state flows and masks for sink and terminal states.
+
+        Args:
+            trajectories: The trajectories data.
+            env: The environment object.
+
+        Returns:
+            log_state_flows: Log state flows.
+            full_mask: A boolean tensor representing full states.
+        """
+        states = trajectories.states
+        log_state_flows = torch.full_like(log_pf_trajectories, fill_value=-float("inf"))
+        mask = ~states.is_sink_state
+        valid_states = states[mask]
+
+        log_F = self.logF(valid_states).squeeze(-1)
+        if self.forward_looking:
+            log_rewards = env.log_reward(states).unsqueeze(-1)
+            log_F = log_F + log_rewards
+
+        log_state_flows[mask[:-1]] = log_F
+        return log_state_flows
+
+    def calculate_masks(
+        self, log_state_flows: TT, trajectories: Trajectories
+    ) -> Tuple[TT, TT, TT]:
+        """
+        Calculate masks for sink and terminal states.
+        """
+        sink_states_mask = log_state_flows == -float("inf")
+        is_terminal_mask = trajectories.actions.is_exit
+        full_mask = sink_states_mask | is_terminal_mask
+
+        return full_mask, sink_states_mask, is_terminal_mask
+
     def get_scores(
         self, env: Env, trajectories: Trajectories
     ) -> Tuple[List[TT[0, float]], List[TT[0, float]]]:
@@ -119,54 +218,27 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
             trajectories, log_pb_trajectories
         )
 
-        states = trajectories.states
-        log_state_flows = torch.full_like(log_pf_trajectories, fill_value=-float("inf"))
-        mask = ~states.is_sink_state
-        valid_states = states[mask]
-
-        log_F = self.logF(valid_states).squeeze(-1)
-        if self.forward_looking:
-            log_rewards = env.log_reward(states).unsqueeze(-1)
-            log_F = log_F + log_rewards
-        log_state_flows[mask[:-1]] = log_F
-
-        sink_states_mask = log_state_flows == -float("inf")
-        is_terminal_mask = trajectories.actions.is_exit
-        full_mask = sink_states_mask | is_terminal_mask
+        log_state_flows = self.calculate_log_state_flows(
+            env, trajectories, log_pf_trajectories
+        )
+        full_mask, sink_states_mask, is_terminal_mask = self.calculate_masks(
+            log_state_flows, trajectories
+        )
 
         flattening_masks = []
         scores = []
         for i in range(1, 1 + trajectories.max_length):
-            current_log_state_flows = (
-                log_state_flows if i == 1 else log_state_flows[: -(i - 1)]
+            preds = self.calculate_preds(log_pf_trajectories_cum, log_state_flows, i)
+            targets = self.calculate_targets(
+                trajectories,
+                preds,
+                log_pb_trajectories_cum,
+                log_state_flows,
+                is_terminal_mask,
+                sink_states_mask,
+                full_mask,
+                i,
             )
-
-            preds = (
-                log_pf_trajectories_cum[i:]
-                - log_pf_trajectories_cum[:-i]
-                + current_log_state_flows
-            )
-
-            targets = torch.full_like(preds, fill_value=-float("inf"))
-            assert trajectories.log_rewards is not None
-            log_rewards = trajectories.log_rewards[
-                trajectories.when_is_done >= i
-            ].clamp_min(self.log_reward_clip_min)
-            targets.T[is_terminal_mask[i - 1 :].T] = log_rewards
-
-            # For now, the targets contain the log-rewards of the ending sub trajectories
-            # We need to add to that the log-probabilities of the backward actions up-to
-            # the sub-trajectory's terminating state
-            if i > 1:
-                targets[is_terminal_mask[i - 1 :]] += (
-                    log_pb_trajectories_cum[i - 1 :] - log_pb_trajectories_cum[: -i + 1]
-                )[:-1][is_terminal_mask[i - 1 :]]
-
-            # The following creates the targets for the non-finishing sub-trajectories
-            targets[~full_mask[i - 1 :]] = (
-                log_pb_trajectories_cum[i:] - log_pb_trajectories_cum[:-i]
-            )[:-1][~full_mask[i - 1 : -1]] + log_state_flows[i:][~sink_states_mask[i:]]
-
             flattening_mask = trajectories.when_is_done.lt(
                 torch.arange(
                     i,
@@ -174,12 +246,12 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
                     device=trajectories.when_is_done.device,
                 ).unsqueeze(-1)
             )
-            flat_preds = preds[~flattening_mask]
-            flat_targets = targets[~flattening_mask]
 
+            flat_preds = preds[~flattening_mask]
             if torch.any(torch.isnan(flat_preds)):
                 raise ValueError("NaN in preds")
 
+            flat_targets = targets[~flattening_mask]
             if torch.any(torch.isnan(flat_targets)):
                 raise ValueError("NaN in targets")
 
@@ -191,83 +263,133 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
             flattening_masks,
         )
 
+    def get_equal_within_contributions(self, trajectories: Trajectories) -> TT:
+        """
+        Calculates contributions for the 'equal_within' weighting method.
+        """
+        is_done = trajectories.when_is_done
+        max_len = trajectories.max_length
+        n_rows = int(max_len * (1 + max_len) / 2)
+
+        # the following tensor represents the inverse of how many sub-trajectories there are in each trajectory
+        contributions = 2.0 / (is_done * (is_done + 1)) / len(trajectories)
+
+        # if we repeat the previous tensor, we get a tensor of shape
+        # (max_len * (max_len + 1) / 2, n_trajectories) that we can multiply with
+        # all_scores to get a loss where each sub-trajectory is weighted equally
+        # within each trajectory.
+        contributions = contributions.repeat(n_rows, 1)
+
+        return contributions
+
+    def get_equal_contributions(self, trajectories: Trajectories) -> TT:
+        """
+        Calculates contributions for the 'equal' weighting method.
+        """
+        is_done = trajectories.when_is_done
+        max_len = trajectories.max_length
+        n_rows = int(max_len * (1 + max_len) / 2)
+        n_sub_trajectories = int((is_done * (is_done + 1) / 2).sum().item())
+        contributions = torch.ones(n_rows, len(trajectories)) / n_sub_trajectories
+        return contributions
+
+    def get_tb_contributions(
+        self, trajectories: Trajectories, all_scores: TT
+    ) -> torch.Tensor:
+        """
+        Calculates contributions for the 'TB' weighting method.
+        """
+        max_len = trajectories.max_length
+        is_done = trajectories.when_is_done
+
+        # Each trajectory contributes one element to the loss, equally weighted
+        contributions = torch.zeros_like(all_scores)
+        indices = (max_len * (is_done - 1) - (is_done - 1) * (is_done - 2) / 2).long()
+        contributions.scatter_(0, indices.unsqueeze(0), 1)
+        contributions = contributions / len(trajectories)
+
+        return contributions
+
+    def get_modified_db_contributions(self, trajectories: Trajectories) -> TT:
+        """
+        Calculates contributions for the 'ModifiedDB' weighting method.
+
+        Args:
+            is_done: Tensor representing when each trajectory is done.
+            n_rows: Number of rows in the all_scores tensor.
+            n_trajectories: Number of trajectories.
+
+        Returns:
+            contributions: Tensor of calculated contributions.
+        """
+        is_done = trajectories.when_is_done
+        max_len = trajectories.max_length
+        n_rows = int(max_len * (1 + max_len) / 2)
+
+        # The following tensor represents the inverse of how many transitions
+        # there are in each trajectory.
+        contributions = (1.0 / is_done / len(trajectories)).repeat(max_len, 1)
+        contributions = torch.cat(
+            (
+                contributions,
+                torch.zeros(
+                    (n_rows - max_len, len(trajectories)),
+                    device=contributions.device,
+                ),
+            ),
+            0,
+        )
+        return contributions
+
+    def get_geometric_within_contributions(self, trajectories: Trajectories) -> TT:
+        """
+        Calculates contributions for the 'geometric_within' weighting method.
+
+        Args:
+            is_done: Tensor representing when each trajectory is done.
+            n_rows: Number of rows in the all_scores tensor.
+            n_trajectories: Number of trajectories.
+            lamda: Lambda factor for geometric series.
+
+        Returns:
+            contributions: Tensor of calculated contributions.
+        """
+        L = self.lamda
+        max_len = trajectories.max_length
+        is_done = trajectories.when_is_done
+
+        # The following tensor represents the weights given to each possible
+        # sub-trajectory length.
+        contributions = (L ** torch.arange(max_len).double()).float()
+        contributions = contributions.unsqueeze(-1).repeat(1, len(trajectories))
+        contributions = contributions.repeat_interleave(
+            torch.arange(max_len, 0, -1),
+            dim=0,
+            output_size=int(max_len * (max_len + 1) / 2),
+        )
+
+        # Now we need to divide each column by n + (n-1) lambda +...+ 1*lambda^{n-1}
+        # where n is the length of the trajectory corresponding to that column
+        # We can do it the ugly way, or using the cool identity:
+        # https://www.wolframalpha.com/input?i=sum%28%28n-i%29+*+lambda+%5Ei%2C+i%3D0..n%29
+        per_trajectory_denom = (
+            1.0
+            / (1 - L) ** 2
+            * (L * (L ** is_done.double() - 1) + (1 - L) * is_done.double())
+        ).float()
+        contributions = contributions / per_trajectory_denom / len(trajectories)
+
+        return contributions
+
     def loss(self, env: Env, trajectories: Trajectories) -> TT[0, float]:
         # Get all scores and masks from the trajectories.
         scores, flattening_masks = self.get_scores(env, trajectories)
         flattening_mask = torch.cat(flattening_masks)
         all_scores = torch.cat(scores, 0)
 
-        # Used only to keep the following calculations clean.
-        L = self.lamda
-        max_len = trajectories.max_length
-        is_done = trajectories.when_is_done
-
-        # all_scores is a tensor of shape (max_len * (max_leng + 1) / 2, n_trajectories)
-        n_rows = int(max_len * (1 + max_len) / 2)
-
-        if self.weighting == "equal_within":
-            # the following tensor represents the inverse of how many sub-trajectories there are in each trajectory
-            contributions = 2.0 / (is_done * (is_done + 1)) / len(trajectories)
-
-            # if we repeat the previous tensor, we get a tensor of shape
-            # (max_len * (max_len + 1) / 2, n_trajectories) that we can multiply with
-            # all_scores to get a loss where each sub-trajectory is weighted equally
-            # within each trajectory.
-            contributions = contributions.repeat(n_rows, 1)
-
-        elif self.weighting == "equal":
-            n_sub_trajectories = int((is_done * (is_done + 1) / 2).sum().item())
-            contributions = torch.ones(n_rows, len(trajectories)) / n_sub_trajectories
-
-        elif self.weighting == "TB":
-            # Each trajectory contributes one element to the loss, equally weighted
-            contributions = torch.zeros_like(all_scores)
-            indices = (
-                max_len * (is_done - 1) - (is_done - 1) * (is_done - 2) / 2
-            ).long()
-            contributions.scatter_(0, indices.unsqueeze(0), 1)
-            contributions = contributions / len(trajectories)
-
-        elif self.weighting == "DB":
+        if self.weighting == "DB":
             # Longer trajectories contribute more to the loss
             return scores[0][~flattening_masks[0]].pow(2).mean()
-
-        elif self.weighting == "ModifiedDB":
-            # The following tensor represents the inverse of how many transitions
-            # there are in each trajectory.
-            contributions = (1.0 / is_done / len(trajectories)).repeat(max_len, 1)
-            contributions = torch.cat(
-                (
-                    contributions,
-                    torch.zeros(
-                        (n_rows - max_len, len(trajectories)),
-                        device=contributions.device,
-                    ),
-                ),
-                0,
-            )
-
-        elif self.weighting == "geometric_within":
-            # The following tensor represents the weights given to each possible
-            # sub-trajectory length.
-            contributions = (L ** torch.arange(max_len).double()).float()
-            contributions = contributions.unsqueeze(-1).repeat(1, len(trajectories))
-            contributions = contributions.repeat_interleave(
-                torch.arange(max_len, 0, -1),
-                dim=0,
-                output_size=int(max_len * (max_len + 1) / 2),
-            )
-
-            # Now we need to divide each column by n + (n-1) lambda +...+ 1*lambda^{n-1}
-            # where n is the length of the trajectory corresponding to that column
-            # We can do it the ugly way, or using the cool identity:
-            # https://www.wolframalpha.com/input?i=sum%28%28n-i%29+*+lambda+%5Ei%2C+i%3D0..n%29
-            per_trajectory_denom = (
-                1.0
-                / (1 - L) ** 2
-                * (L * (L ** is_done.double() - 1) + (1 - L) * is_done.double())
-            ).float()
-            contributions = contributions / per_trajectory_denom / len(trajectories)
 
         elif self.weighting == "geometric":
             # The position i of the following 1D tensor represents the number of sub-
@@ -285,12 +407,30 @@ class SubTBGFlowNet(TrajectoryBasedGFlowNet):
                     for scores, flattening_mask in zip(scores, flattening_masks)
                 ]
             )
+            max_len = trajectories.max_length
+            L = self.lamda
             ratio = (1 - L) / (1 - L**max_len)
             weights = ratio * (
                 L ** torch.arange(max_len, device=per_length_losses.device)
             )
             assert (weights.sum() - 1.0).abs() < 1e-5, f"{weights.sum()}"
             return (per_length_losses * weights).sum()
+
+        elif self.weighting == "equal_within":
+            contributions = self.get_equal_within_contributions(trajectories)
+
+        elif self.weighting == "equal":
+            contributions = self.get_equal_contributions(trajectories)
+
+        elif self.weighting == "TB":
+            contributions = self.get_tb_contributions(trajectories, all_scores)
+
+        elif self.weighting == "ModifiedDB":
+            contributions = self.get_modified_db_contributions(trajectories)
+
+        elif self.weighting == "geometric_within":
+            contributions = self.get_geometric_within_contributions(trajectories)
+
         else:
             raise ValueError(f"Unknown weighting method {self.weighting}")
 


### PR DESCRIPTION
This PR attempts to tackle #117: Simplify `SubTBGFlowNet.get_scores` and `SubTBGFlowNet.loss`

Most importantly, in this PR, `SubTBGFlowNet.loss` is reduced to:

```py
    def loss(self, env: Env, trajectories: Trajectories) -> TT[0, float]:
        # Get all scores and masks from the trajectories.
        scores, flattening_masks = self.get_scores(env, trajectories)
        flattening_mask = torch.cat(flattening_masks)
        all_scores = torch.cat(scores, 0)

        if self.weighting == "DB":
            # Longer trajectories contribute more to the loss
            return scores[0][~flattening_masks[0]].pow(2).mean()

        elif self.weighting == "geometric":
            # The position i of the following 1D tensor represents the number of sub-
            # trajectories of length i in the batch.
            # n_sub_trajectories = torch.maximum(
            #     trajectories.when_is_done - torch.arange(3).unsqueeze(-1),
            #     torch.tensor(0),
            # ).sum(1)

            # The following tensor's k-th entry represents the mean of all losses of
            # sub-trajectories of length k.
            per_length_losses = torch.stack(
                [
                    scores[~flattening_mask].pow(2).mean()
                    for scores, flattening_mask in zip(scores, flattening_masks)
                ]
            )
            max_len = trajectories.max_length
            L = self.lamda
            ratio = (1 - L) / (1 - L**max_len)
            weights = ratio * (
                L ** torch.arange(max_len, device=per_length_losses.device)
            )
            assert (weights.sum() - 1.0).abs() < 1e-5, f"{weights.sum()}"
            return (per_length_losses * weights).sum()

        elif self.weighting == "equal_within":
            contributions = self.get_equal_within_contributions(trajectories)

        elif self.weighting == "equal":
            contributions = self.get_equal_contributions(trajectories)

        elif self.weighting == "TB":
            contributions = self.get_tb_contributions(trajectories, all_scores)

        elif self.weighting == "ModifiedDB":
            contributions = self.get_modified_db_contributions(trajectories)

        elif self.weighting == "geometric_within":
            contributions = self.get_geometric_within_contributions(trajectories)
        else:
            raise ValueError(f"Unknown weighting method {self.weighting}")

        flat_contributions = contributions[~flattening_mask]
        assert (
            flat_contributions.sum() - 1.0
        ).abs() < 1e-5, f"{flat_contributions.sum()}"
        losses = flat_contributions * all_scores[~flattening_mask].pow(2)
        return losses.sum()
```

The only additional change I debated here was whether or not to encapsulate that final loss calculation into an anonymous function like this:

```py
def loss_from_contributions(contributions):
  flat_contributions = contributions[~flattening_mask]
        assert (
            flat_contributions.sum() - 1.0
        ).abs() < 1e-5, f"{flat_contributions.sum()}"
        losses = flat_contributions * all_scores[~flattening_mask].pow(2)
        return losses.sum()
```

And then in the last few branches, you'd have:

```py
        elif self.weighting == "equal_within":
            contributions = self.get_equal_within_contributions(trajectories)
            return loss_from_contributions(contributions)

        elif self.weighting == "equal":
            contributions = self.get_equal_contributions(trajectories)
            return loss_from_contributions(contributions)

        elif self.weighting == "TB":
            contributions = self.get_tb_contributions(trajectories, all_scores)
            return loss_from_contributions(contributions)

        elif self.weighting == "ModifiedDB":
            contributions = self.get_modified_db_contributions(trajectories)
            return loss_from_contributions(contributions)

        elif self.weighting == "geometric_within":
            contributions = self.get_geometric_within_contributions(trajectories)
            return loss_from_contributions(contributions)

        else:
            raise ValueError(f"Unknown weighting method {self.weighting}")
```

This is nice because then every branch returns out of the function as opposed to having the last several fall through to the higher scope. It incurs a little bit of copy-pasta though and I generally try to avoid that kind of function nesting if I can help it. So given that, I decided to leave the higher level control flow as is but I'd be happy to make this change if y'all would prefer.

There are some additional simplifications to `get_scores` as well but they're less controversial. 

NB, there is a lot of moving around of code here so I think the inline diff viewer isn't really optimal here. The side-by-side diff viewer is better but still not great. I'd suggest reading both the old version of each function alongside the new version of each function for optimal review readability. 